### PR TITLE
bmp280 BigNumbers

### DIFF
--- a/sensors/bmp280-node.js
+++ b/sensors/bmp280-node.js
@@ -25,6 +25,7 @@ module.exports = function (RED) {
   const os = require('os');
   // NPM Imports
   const i2c = require('i2c-bus');
+  const BigNumber = require('bignumber.js');
 
   // Local Imports
   // const Measurement = require('./Measurement.js');


### PR DESCRIPTION
Added missing bigNumbers.js to bmp280.js so node will stop crashing when attempting to use in node-red.